### PR TITLE
Housing: Complete bill of materials

### DIFF
--- a/bom.md
+++ b/bom.md
@@ -5,14 +5,13 @@ List of major components (resistors and capacitors are left out).
 All prices without VAT unless otherwise noted and without discount for higher order volume.
 
 ## Power Supply
-
 When 48V phantom power is not urgently needed, just use a Mean Well RT-50C power supply to provide +15V, -15V and +5V.
-Otherwise a way to create clean 48V from one of these power rails is needed, but we want to use dynamic microphones anyways.
+Otherwise a way to create clean 48V from one of these power rails is needed, but we want to only use dynamic microphones anyways.
+
 
 ## Housing
 All components fit in the off-the-shelf Hammond Manufacturing 1456PH3 housing.
 But drilling and routing the holes in already bent metal sheets may be difficult
-
 
 ### Custom Housing
 The Design is based on the Hammond Manufacturing 1456PH3 with a reduced width and increased hight of the Channel I/O Section
@@ -34,56 +33,58 @@ The Design is based on the Hammond Manufacturing 1456PH3 with a reduced width an
 
 
 ## Boards
+The PCBs with all SMD components cost about 40€ per console (depending on order volume and shipping option).
+Additional components like power supply, connectors, etc. add up to about 100€ per console.
 
 ### Line I/O Board Components
 BOM for one PCB, needed 1x for whole assembly.
 Electrolytic capacitors should have 25 V voltage rating, unless otherwise specified.
 
-| Count | Manufacturer + Art. No.   | Description                       | €/ pc.| Distributor Order No.
-|-------|---------------------------|-----------------------------------|-------|----------------------
-| 1     | Neutrik NCJ6FA-H          | Stage Line Input                  | 1.70  | Voelkner D21915, Thomann 250931
-| 1     | Neutrik NC3MAAH           | Mix Line Output                   | 1.00  | Voelkner X39973, Mouser 568-NC3MAAH
-| 1     | SPTAF 1/ 4-3,5-EL         | PCB PowerSupply                   | 1.26  | Mouser 651-1862068
-| 3     | WE WR-BHD 61201021621     | IDC socket, Interconn. to channel | 0.37  | Mouser 710-61201021621
-| 1     | CTS 195-2MST              | DIP switch vertical               | 0.47  | Mouser 774-1952MST
-| 1     | Keystone test point 5006  | TEST POINT BLK .063               | 0.32  | Mouser 534-5006
-| 1     | LM833-N                   | Generic Op-Amp                    | PCBA  | JLC C473907
-| 1     | DRV135UA                  | Line Driver                       | PCBA  | JLC C431073
-| 1     | Mean Well RT-50C          | Power Suppy                       | 18.50 | Voelkner A246532
-| 1     | TC-10475840               | IEC C14 Socket, screwed, M3, 40mm | 1.50  | Voelkner X960872 (alternative. D28684)
+| Count | Manufacturer + Art. No.   | Description                       | Distributor Order No.
+|-------|---------------------------|-----------------------------------|----------------------
+| 1     | Neutrik NCJ6FA-H          | Stage Line Input                  | Voelkner D21915, Thomann 250931
+| 1     | Neutrik NC3MAAH           | Mix Line Output                   | Voelkner X39973, Mouser 568-NC3MAAH
+| 1     | SPTAF 1/ 4-3,5-EL         | PCB PowerSupply                   | Mouser 651-1862068
+| 3     | WE WR-BHD 61201021621     | IDC socket, Interconn. to channel | Mouser 710-61201021621
+| 1     | CTS 195-2MST              | DIP switch vertical               | Mouser 774-1952MST
+| 1     | Keystone test point 5006  | TEST POINT BLK .063               | Mouser 534-5006
+| 1     | Mean Well RT-50C          | Power Suppy                       | Voelkner A246532
+| 1     | TC-10475840               | IEC C14 Socket, screwed, M3, 40mm | Voelkner X960872 (alternative. D28684)
+| 1     | LM833-N                   | Generic Op-Amp                    | JLC C473907 (usually ordered with PCB assembly)
+| 1     | DRV135UA                  | Line Driver                       | JLC C431073 (usually ordered with PCB assembly)
 
 
 #### Channel Strip Components
 BOM for one PCB, needed 3x for whole assembly.
 Electrolytic capacitors should have 25 V voltage rating, unless otherwise specified.
 
-| Count | Model or Art. No.         | Description                       | €/ pc.| Distributor Order No.
-|-------|---------------------------|-----------------------------------|-------|----------------------
-| 1     | Neutrik NC3FAAH2          | Microphone Input                  | 1.20  | Voelkner X39703, Mouser 568-NC3FAAH-2
-| 1     | Rean NYS 216 or 216G      | Headphone Output                  | 0.64  | Mouser 568-NYS216-U
-| 1     | WE WR-BHD 61201021721     | Mix Interconn. to Line I/O, horiz.| 0.49  | Mouser 710-61201021721
-| 2     | WE WR-BHD 61200821721     | Mix Interconn. w/ Ch. I/O, horiz. | 0.89  | Mouser 710-61200821721
-| 1     | BKL 10120667              | IDC cable 8-pole, 25cm            | 2.20  | Reichelt
-| 1     | BKL 10120668              | IDC cable 10-pole, 25cm           | 2.25  | Reichelt
-| 1     | Molex 22-28-8024          | Pin header to Mute btn. , horiz.  | 0.09  | Mouser 538-22-28-8024
-| 4     | CUI PTN091-V50115K1A      | 50K log. (vert.) Heads. Mix +Gain | 1.64  | Mouser 179-PTN091V50115K1A
-| 1     | Alps RK09K1110B1R         | 50K log. (horiz.) Vol.            | 0.67  | Mouser 688-RK09K1110B1R
-| 3     | Davies Molding 1106-WA    | Potentiometer Knob f. Mix (star)  | 0.82  | Mouser 5164-1106-WA
-| 1     | Davies Molding 1108       | Potentiometer Knob f. Vol. (D)    | 0.99  | Mouser 5164-1108
-| 1     | Cliff CL170842CR (red)    | Potentiometer Knob f. Gain (star) | 0.47  | Voelkner D71805
-| 1     | APEM MHPS2273             | OnAir Switch                      | 0.41  | Mouser 642-MHPS2273
-| 1     | APEM MH15 (alt. U4535)    | On-Air Button yellow cap          | 0.17  | Mouser 642-MH12
-| 1     | Adafruit 3430             | Adafruit Arcade button (red)      | 2.15  | Mouser 485-3430
-| 3     | LM339                     | Quad Diff. Comparators            | PCBA  | JLC C7948
-| 1     | LM833-N                   | Generic Op-Amp                    | PCBA  | JLC C473907
-| 1     | NE5534                    | Low-noise bipolar Op-Amp          | PCBA  | JLC C9916
-| 1     | TL072{C,I,HI}DR           | Low-noise FET Op-Amp              | PCBA  | JLC C67473
-| 1     | TPA6111A2                 | Headphone Amp                     | PCBA  | JLC C497472
-| 3     | Kingbright WP113GDT       | 2x5mm Rectangular LED, green      | 0.20  | Mouser 604-WP113GDT (alternative: 859-LTL-433G)
-| 6     | Kingbright WP113YDT       | 2x5mm Rectangular LED, yellow     | 0.17  | Mouser 604-WP113YDT (alternative: 859-LTL-433Y)
-| 3     | Kingbright WP113IDT       | 2x5mm Rectangular LED, red        | 0.22  | Mouser 604-WP113IDT (alternative: 859-LTL-433HR)
-| 12    | Fischer RAH 504           | 4mm spacer, square                | 0.30  | Reichelt FIS RAH 504
-| 1     | Kingbright WP710A10LID    | 3mm diffused LED, red             | 0.15  | Mouser 604-WP710A10LID
-| 1     | Fischer MAH 308           | 8mm spacer, 3mm round             | 0.07  | Reichelt FIS MAH 308
-| 7     | 1N4148                    | Signal Diode SOD-123              | PCBA  | JLC C7420318
-| 1     | J113                      | SMD J-FET SOT-23                  | PCBA  | JLC C891686
+| Count | Model or Art. No.         | Description                       | Distributor Order No.
+|-------|---------------------------|-----------------------------------|----------------------
+|  1    | Neutrik NC3FAAH2          | Microphone Input                  | Voelkner X39703, Mouser 568-NC3FAAH-2
+|  1    | Rean NYS 216 or 216G      | Headphone Output                  | Mouser 568-NYS216-U
+|  1    | WE WR-BHD 61201021721     | Mix Interconn. to Line I/O, horiz.| Mouser 710-61201021721
+|  2    | WE WR-BHD 61200821721     | Mix Interconn. w/ Ch. I/O, horiz. | Mouser 710-61200821721
+|  1    | BKL 10120667              | IDC cable 8-pole, 25cm            | Reichelt
+|  1    | BKL 10120668              | IDC cable 10-pole, 25cm           | Reichelt
+|  1    | Molex 22-28-8024          | Pin header to Mute btn. , horiz.  | Mouser 538-22-28-8024
+|  4    | CUI PTN091-V50115K1A      | 50K log. (vert.) Heads. Mix +Gain | Mouser 179-PTN091V50115K1A
+|  1    | Alps RK09K1110B1R         | 50K log. (horiz.) Vol.            | Mouser 688-RK09K1110B1R
+|  3    | Davies Molding 1106-WA    | Potentiometer Knob f. Mix (star)  | Mouser 5164-1106-WA
+|  1    | Davies Molding 1108       | Potentiometer Knob f. Vol. (D)    | Mouser 5164-1108
+|  1    | Cliff CL170842CR (red)    | Potentiometer Knob f. Gain (star) | Voelkner D71805
+|  1    | APEM MHPS2273             | OnAir Switch                      | Mouser 642-MHPS2273
+|  1    | APEM MH15 (alt. U4535)    | On-Air Button yellow cap          | Mouser 642-MH12
+|  1    | Adafruit 3430             | Adafruit Arcade button (red)      | Mouser 485-3430
+|  3    | Kingbright WP113GDT       | 2x5mm Rectangular LED, green      | Mouser 604-WP113GDT (alternative: 859-LTL-433G)
+|  6    | Kingbright WP113YDT       | 2x5mm Rectangular LED, yellow     | Mouser 604-WP113YDT (alternative: 859-LTL-433Y)
+|  3    | Kingbright WP113IDT       | 2x5mm Rectangular LED, red        | Mouser 604-WP113IDT (alternative: 859-LTL-433HR)
+| 12    | Fischer RAH 504           | 4mm spacer, square                | Reichelt FIS RAH 504
+|  1    | Kingbright WP710A10LID    | 3mm diffused LED, red             | Mouser 604-WP710A10LID
+|  1    | Fischer MAH 308           | 8mm spacer, 3mm round             | Reichelt FIS MAH 308
+|  3    | LM339                     | Quad Diff. Comparators            | JLC C7948 (usually ordered with PCB assembly)
+|  1    | LM833-N                   | Generic Op-Amp                    | JLC C473907 (usually ordered with PCB assembly)
+|  1    | NE5534                    | Low-noise bipolar Op-Amp          | JLC C9916 (usually ordered with PCB assembly)
+|  1    | TL072{C,I,HI}DR           | Low-noise FET Op-Amp              | JLC C67473 (usually ordered with PCB assembly)
+|  1    | TPA6111A2                 | Headphone Amp                     | JLC C497472 (usually ordered with PCB assembly)
+|  7    | 1N4148                    | Signal Diode SOD-123              | JLC C7420318 (usually ordered with PCB assembly)
+|  1    | J113                      | SMD J-FET SOT-23                  | JLC C891686 (usually ordered with PCB assembly)


### PR DESCRIPTION
Extend housing BOM with missing fasteners

TODO:

- [x] are M3 nuts needed for fastening the C14 socket or did we have threads cut? If the latter, 5mm screws would be fine