### PR TITLE
Mechanical: Add assembly helpers

### DIFF
--- a/mechanical/README.md
+++ b/mechanical/README.md
@@ -1,5 +1,10 @@
-# Housing
+# Housing and 3D Printed Parts
 
+## Housing
+The housing is made from bend sheet metal and designed in FreeCAD.
 
-## Requirements
+### Requirements
 - FreeCAD 1.x with SheetMetal Workbench Addon installed
+
+## Assembly Helpers
+To place the level meter (aka. VU meter) LEDs at the needed height, an assembly helper is available at [./assembly-helpers/vumeter-leds.scad](./assembly-helpers/vumeter-leds.scad).

--- a/mechanical/assembly-helpers/vumeter-leds.scad
+++ b/mechanical/assembly-helpers/vumeter-leds.scad
@@ -1,0 +1,48 @@
+wall        = 2.0;
+depth       = 11.5;
+
+led_count   = 12;
+led_width   = 5.5;
+led_height  = 2.0;
+led_space   = 0.5;
+
+all_length = led_count*(led_height + led_space);
+
+// main housing
+difference() {
+    cube([all_length + 2*wall,
+      led_width + 2*wall,
+      depth + wall]);
+    
+    translate([wall,wall,wall]) {
+        // LED cutout
+        cube([all_length,
+              led_width,
+              depth]);
+        
+        // resistor cutout
+        cutout_depth = 1;
+        cutout_diff = 0.5;
+        translate([+cutout_diff/2,led_width,depth-cutout_depth]) {
+            cube([all_length - cutout_diff, wall, cutout_depth]);
+        }
+        
+        // capacitor cutout
+        cutout_len = 3.5;
+        cutout_offset = 0.8;
+        translate([all_length,((led_width-cutout_len)/2+cutout_offset),depth-cutout_depth]) {
+            cube([wall, cutout_len, cutout_depth]);
+        }
+    }
+}
+
+// ribs
+rib_gap = 0.2;
+rib_height = 2.5;
+translate([wall+led_height+(rib_gap/2)+(led_space/2), wall, wall]){
+    for (i = [0 : 1 : (led_count-2)]) {
+        translate([i*(led_height+led_space), 0, 0]){
+            cube([led_space - rib_gap, led_width, rib_height]);
+        }
+    }
+}


### PR DESCRIPTION
To put all 12 level meter LEDs in at the right height as well as properly aligned, some assembly guide is needed. It comes in the form of a small cavity with separations for keep the LEDs neatly spaced out.